### PR TITLE
adding mev-mock-relay

### DIFF
--- a/playbooks/setup_mock_relay.yml
+++ b/playbooks/setup_mock_relay.yml
@@ -1,0 +1,18 @@
+- name: Start mock relay
+  hosts: mock_relay
+  gather_facts: true
+  serial: 20
+  tasks:
+    - name: Read config file
+      shell: cat "{{ home_dir }}/jwtsecret"
+      register: jwt_secret
+    - name: Start mock relay
+      docker_container:
+        name: "{{ mock_relay_container_name }}"
+        state: started
+        image: "{{ mock_relay_image_name }}"
+        pull: true
+        restart_policy: unless-stopped
+        network_mode: host
+        restart: "{{ mev_relay_require_restart | default(false) }}"
+        command: "{{ mock_relay_start_args }}"

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/all.yaml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/all.yaml
@@ -74,6 +74,15 @@ ethstats_url: "ethstats.withdrawal-mainnet-shadowfork-2.ethpandaops.io"
 ethstats_password: "withdrawalmainnetshadowfork2"
 
 ##############################################
+# mev boost configs
+##############################################
+mev_boost_image_name: flashbots/mev-boost:1.5.0-capella-alpha3-portable
+mev_boost_container_name: mev_boost
+mev_boost_start_args: "-zhejiang -relay-check -relays https://0xb23a28ab075ea0d76732c657bcd81fa3c4bc50831691fc30063bd9ce3b6181bc2c0f1828b32d465d91669d30d283315c@boost-relay-zhejiang.flashbots.net"
+mev_boost: true
+mev_builder_endpoint: "http://{{hostvars[groups['bootnode'][0]]['ansible_host']}}:{{mev_boost_port}}"
+
+##############################################
 # ports to configure
 ##############################################
 el_rpc_port: 8545
@@ -93,6 +102,7 @@ node_exporter_web_listen_address: "0.0.0.0:9100"
 prometheus_web_listen_address: "0.0.0.0:9101"
 el_metrics_port: 8002
 eth_metrics_exporter_port: 8003
+mev_boost_port: 18550
 
 ##############################################
 # Command for JSON RPC snooper
@@ -154,6 +164,7 @@ firewall_allowed_tcp_ports:
   - 9000
   - 80
   - 443
+  - 18550
 
 firewall_allowed_udp_ports:
   - 30303

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/lighthouse.yml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/lighthouse.yml
@@ -59,7 +59,9 @@ beacon_start_args: >
   --execution-endpoint={{execution_endpoint}}
   --suggested-fee-recipient={{fee_recipient}}
   --execution-jwt="/jwtsecret"
-
+  {% if mev_boost|bool is sameas true %}
+  --builder="{{mev_builder_endpoint}}"
+  {% endif %}
 # in case of eth1 deposit endpoint problems: --dummy-eth1
 
 validator_start_args: >
@@ -78,7 +80,9 @@ validator_start_args: >
   --http --http-port={{validator_rpc_port}}
   --metrics --metrics-address 0.0.0.0 --metrics-port "{{validator_metrics_port}}"
   --suggested-fee-recipient={{fee_recipient}}
-
+  {% if mev_boost|bool is sameas true %}
+  --builder-proposals
+  {% endif %}
 
 ##############################################
 # file permissions and user ids

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/lodestar.yml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/lodestar.yml
@@ -62,7 +62,9 @@ beacon_start_args: >
         --metrics.port={{ beacon_metrics_port }}
         --jwt-secret="/jwtsecret"
         --suggestedFeeRecipient={{fee_recipient}}
-
+        {% if mev_boost|bool is sameas true %}
+        --builder --builder.urls="{{mev_builder_endpoint}}"
+        {% endif %}
 
 validator_start_args: >
   validator
@@ -77,7 +79,9 @@ validator_start_args: >
    --server={{beacon_endpoint}}
    --graffiti={{graffiti}}
    --suggestedFeeRecipient={{fee_recipient}}
-
+   {% if mev_boost|bool is sameas true %}
+   --builder
+   {% endif %}
 
 ##############################################
 # memory limits

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/mock_relay.yml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/mock_relay.yml
@@ -1,0 +1,17 @@
+##############################################
+# generic relay info
+##############################################
+mock_relay_container_name: mock_relay
+mock_relay_image_name: parithoshj/mock-builder:v1.0.1
+mev_relay_require_restart: true
+mev_relay_port: 18550
+
+##############################################
+# specifies when to start invalid payloads from
+##############################################
+mock_relay_invalidate_epoch_from: 9999999
+mock_relay_invalidation_type: "parent_hash"
+##############################################
+# relay start arg
+##############################################
+mock_relay_start_args: "-port={{mev_relay_port}} -jwt-secret={{ jwt_secret.stdout }} -bid-multiplier=2 -invalidate-payload={{ mock_relay_invalidate_epoch_from }},{{mock_relay_invalidation_type}} -cl={{hostvars[groups['bootnode'][0]]['ansible_host']}}:{{beacon_api_port}} -el={{hostvars[groups['bootnode'][0]]['ansible_host']}}:{{el_engine_port}}"

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/nimbus.yml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/nimbus.yml
@@ -65,7 +65,9 @@ beacon_start_args: >
   --jwt-secret=/jwtsecret
   --dump:on
   --history=prune
-
+  {% if mev_boost|bool is sameas true %}
+  --payload-builder=true --payload-builder-url="{{mev_builder_endpoint}}"
+  {% endif %}
 
 ##############################################
 # file permissions and user ids

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/prysm.yml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/prysm.yml
@@ -68,7 +68,9 @@ beacon_start_args: >
   --enable-debug-rpc-endpoints
   --jwt-secret=/jwtsecret
   --suggested-fee-recipient={{ fee_recipient }}
-
+  {% if mev_boost is sameas true %}
+  --http-mev-relay="{{mev_builder_endpoint}}"
+  {% endif %}
 
 validator_start_args: >
   --accept-terms-of-use=true
@@ -84,7 +86,9 @@ validator_start_args: >
   --suggested-fee-recipient={{ fee_recipient }}
   --wallet-dir=/validatordata/wallet
   --wallet-password-file="/validatordata/wallet_pass.txt"
-
+  {% if mev_boost|bool is sameas true %}
+  --enable-builder
+  {% endif %}
 
 ##############################################
 # file permissions and user ids

--- a/withdrawal-mainnet-shadowfork-2/inventory/group_vars/teku.yml
+++ b/withdrawal-mainnet-shadowfork-2/inventory/group_vars/teku.yml
@@ -62,6 +62,10 @@ beacon_start_args: >
   --validator-keys="/validatordata/keys:/validatordata/secrets"
   --validators-keystore-locking-enabled=false
   {% endif %}
+  {% if mev_boost|bool is sameas true %}
+  --builder-endpoint="{{ mev_builder_endpoint }}"
+  --validators-builder-registration-default-enabled=true
+  {% endif %}
   --ee-jwt-secret-file="/jwtsecret"
   --log-destination=console
 

--- a/withdrawal-mainnet-shadowfork-2/inventory/inventory.ini
+++ b/withdrawal-mainnet-shadowfork-2/inventory/inventory.ini
@@ -123,6 +123,9 @@ beacon
 [txfuzz:children]
 bootnode
 
+[mock_relay:children]
+bootnode
+
 [forkmon:children]
 bootnode
 


### PR DESCRIPTION
- Adds a mock relay
- Configures mock relay on bootnode
- Sets all validators to rely on mock relay
- Allows us to set an invalidation parameter to check for bad block building